### PR TITLE
FIX: SPC 662 fix warning when stream buffers

### DIFF
--- a/Interface/react/src/components/videojsPlayer.tsx
+++ b/Interface/react/src/components/videojsPlayer.tsx
@@ -109,11 +109,14 @@ export function VideoPlayer(props: VideoPlayerProps) {
       //passing any argument suppresses a warning about accessing the tech
       let tech = playerRef.current?.tech({ randomArg: true })
       if (tech) {
-        //ensure that the current playing segment has a uri
-        if (tech.textTracks()[0].activeCues[0]['value'].uri) {
-          //console.log('value:', tech.textTracks()[0].activeCues[0]['value'].uri)
-          return tech.textTracks()[0].activeCues[0]['value'].uri
-        }
+        //Lovely if nesting because typescript, make sure everything is defined before accessing
+        if (tech.textTracks())
+          if (tech.textTracks()[0].activeCues[0])
+            if (tech.textTracks()[0].activeCues[0]['value'].uri) {
+              return tech.textTracks()[0].activeCues[0]['value'].uri
+            }
+        //In case something is not defined yet
+        return undefined
       }
     } catch (e) {
       console.warn(e)

--- a/Interface/react/src/components/videojsPlayer.tsx
+++ b/Interface/react/src/components/videojsPlayer.tsx
@@ -109,7 +109,7 @@ export function VideoPlayer(props: VideoPlayerProps) {
       //passing any argument suppresses a warning about accessing the tech
       let tech = playerRef.current?.tech({ randomArg: true })
       if (tech) {
-        //Lovely if nesting because typescript, make sure everything is defined before accessing
+        //make sure everything is defined before accessing
         if (tech.textTracks())
           if (tech.textTracks()[0].activeCues[0])
             if (tech.textTracks()[0].activeCues[0]['value'].uri) {


### PR DESCRIPTION
If a stream buffers on first play it would spam the console with a warning saying something is undefined.
Fixed by adding more checks if everything is defined before accessing.