### PR TITLE
Lock numpy version and silence warning

### DIFF
--- a/CameraProcessor/pytest.ini
+++ b/CameraProcessor/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning:past
+    ignore::DeprecationWarning:tensorboard
+    ignore::DeprecationWarning:thop

--- a/CameraProcessor/requirements.txt
+++ b/CameraProcessor/requirements.txt
@@ -3,6 +3,7 @@
 
 # General imports
 tornado==6.1
+numpy~=1.19.0
 
 # Threading / Async
 threaded==4.1.0


### PR DESCRIPTION
Versions need to get upgraded in order to resolve the warning
Numpy version is locked so it does not go to 1.20, actual deprecation should not occur