### PR TITLE
FFT: Added authentication message on websocket open

### DIFF
--- a/Interface/react/src/app.tsx
+++ b/Interface/react/src/app.tsx
@@ -34,14 +34,14 @@ export function App() {
         return <NeedLogin />
       case 'authenticated':
         return (
-          <>
+          <WebsocketProvider>
             <Route exact path='/'>
               <Home />
             </Route>
             <Route exact path='/timelines'>
               <Timelines />
             </Route>
-          </>
+          </WebsocketProvider>
         )
     }
   }
@@ -56,12 +56,10 @@ export function App() {
       }}
     >
       {/* Shows the navbar and page contents depending on user authentication */}
-      <WebsocketProvider>
-        <BrowserRouter key={1}>
-          <NavMenu key={0} />
-          {body()}
-        </BrowserRouter>
-      </WebsocketProvider>
+      <BrowserRouter key={1}>
+        <NavMenu key={0} />
+        {body()}
+      </BrowserRouter>
     </Layout>
   )
 }

--- a/Interface/react/src/classes/orchestratorMessage.ts
+++ b/Interface/react/src/classes/orchestratorMessage.ts
@@ -67,3 +67,17 @@ export class SetUsesImagesMessage extends OrchestratorMessage {
 
   usesImages: boolean
 }
+
+/**
+ * The AuthenticateOrchestratorMessage is used to authenticate this client with the
+ * processor orchestrator, to make sure it handles the messages.
+ */
+export class AuthenticateOrchestratorMessage extends OrchestratorMessage {
+  constructor(jwt: string) {
+    super('authenticate')
+
+    this.jwt = jwt
+  }
+
+  jwt: string
+}

--- a/Interface/react/src/components/websocketContext.tsx
+++ b/Interface/react/src/components/websocketContext.tsx
@@ -7,10 +7,12 @@ Utrecht University within the Software Project course.
  */
 
 import React, { ReactNode } from 'react'
+import { useKeycloak } from '@react-keycloak/web'
 
 import {
   OrchestratorMessage,
-  SetUsesImagesMessage
+  SetUsesImagesMessage,
+  AuthenticateOrchestratorMessage
 } from '../classes/orchestratorMessage'
 import {
   Box,
@@ -78,6 +80,9 @@ export function WebsocketProvider(props: WebsocketProviderProps) {
   /** State keeping track of objects that were added */
   const [objects, setObjects] = React.useState<NewObjectClientMessage[]>([])
 
+  //
+  const { keycloak } = useKeycloak()
+
   const socketRef = React.useRef<WebSocket>()
   const listenersRef = React.useRef<Listener[]>([])
   const listenerRef = React.useRef<number>(0)
@@ -103,6 +108,9 @@ export function WebsocketProvider(props: WebsocketProviderProps) {
     setConnectionState('OPEN')
 
     try {
+      // Authenticate the client
+      if (keycloak.token)
+        send(new AuthenticateOrchestratorMessage(keycloak.token))
       // Let the orchestrator know that this client should receive images of new tracking objects
       send(new SetUsesImagesMessage(true))
     } catch {

--- a/Interface/react/testing/unit testing/orchestratorMessage.test.tsx
+++ b/Interface/react/testing/unit testing/orchestratorMessage.test.tsx
@@ -9,7 +9,8 @@ Utrecht University within the Software Project course.
 import React from 'react'
 import {
   StartOrchestratorMessage,
-  StopOrchestratorMessage
+  StopOrchestratorMessage,
+  AuthenticateOrchestratorMessage
 } from '../../src/classes/orchestratorMessage'
 
 //Test the start message that gets sent to the orchestrator
@@ -32,4 +33,14 @@ test('StopOrchestratorMessage', () => {
   expect(msg.type).toBe('stop')
   //Ensure arguments are correct
   expect(msg.objectId).toBe(495)
+})
+
+//Test the authenticate message sent to the orchestrator to stop tracking
+test('AuthenticateOrchestratorMessage', () => {
+  const msg = new AuthenticateOrchestratorMessage('test')
+
+  //Ensure the 'authenticate' type gets assigned correctly
+  expect(msg.type).toBe('authenticate')
+  //Ensure arguments are correct
+  expect(msg.jwt).toBe('test')
 })


### PR DESCRIPTION
Moved websocketcontext so that it doesn't open before authentication. The jwt token from authentication is then used in an authentication message to the orchestrator