### PR TITLE
FFT: Remove camera id from the configs.ini

### DIFF
--- a/CameraProcessor/configs.ini
+++ b/CameraProcessor/configs.ini
@@ -14,7 +14,6 @@ webcam_device_nr = 0
 images_dir_path = ./data/annotated/test/img1
 video_file_path = ./data/videos/venice.mp4
 hls_url = https://tracktech.ml:50008/stream.m3u8
-camera_id = test id
 
 [Orchestrator]
 sec_url = wss://tracktech.ml:50010/processor

--- a/CameraProcessor/configs.ini
+++ b/CameraProcessor/configs.ini
@@ -16,9 +16,7 @@ video_file_path = ./data/videos/venice.mp4
 hls_url = https://tracktech.ml:50008/stream.m3u8
 
 [Orchestrator]
-sec_url = wss://tracktech.ml:50010/processor
-url = ws://tracktech.ml:50010/processor
-local_url = ws://localhost:80/processor
+url = wss://tracktech.ml:50011/processor
 
 [Yolov5]
 source_path = ./data/videos/short_venice.mp4

--- a/CameraProcessor/processor/main.py
+++ b/CameraProcessor/processor/main.py
@@ -5,6 +5,7 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 
+import os
 import sys
 import logging
 import asyncio
@@ -77,7 +78,8 @@ def main():
     Deploy first needs to connect with the orchestrator before it is able to start the asyncio loop
 
     Raises:
-        AttributeError: Mode in which is ran does not exist.
+        AttributeError: Mode in which is run does not exist.
+        EnvironmentError: CAMERA_ID is missing, but the application is running in deploy mode.
     """
     # Load the config file.
     config_parser = ConfigParser('configs.ini', True)
@@ -97,7 +99,11 @@ def main():
         )
     # Deploy mode where all is sent to the orchestrator using the websocket url.
     elif configs['Main']['mode'].lower() == 'deploy':
-        websocket_id = configs['Input']['camera_id']
+        # Make sure camera id is set to identify the processor.
+        websocket_id = os.getenv('CAMERA_ID')
+        if websocket_id is None:
+            logging.error('CAMERA_ID not set in environment.')
+            raise EnvironmentError('Environment variable CAMERA_ID is missing but is required during deployment.')
         asyncio.get_event_loop().run_until_complete(deploy(configs, websocket_id))
     else:
         raise AttributeError("Mode you try to run in does not exist, did you make a typo?")

--- a/CameraProcessor/processor/utils/config_parser.py
+++ b/CameraProcessor/processor/utils/config_parser.py
@@ -90,7 +90,6 @@ class ConfigParser:
 
         # Read all the environment variables and set them if they are defined.
         self.configs['Orchestrator']['url'] = os.getenv('ORCHESTRATOR_URL') or self.configs['Orchestrator']['url']
-        self.configs['Input']['camera_id'] = os.getenv('CAMERA_ID') or self.configs['Input']['camera_id']
         self.configs['Main']['mode'] = os.getenv('PROCESSOR_MODE') or self.configs['Main']['mode']
         self.configs['Main']['detector'] = os.getenv('DETECTION_ALG') or self.configs['Main']['detector']
         self.configs['Main']['tracker'] = os.getenv('TRACKING_ALG') or self.configs['Main']['tracker']


### PR DESCRIPTION
Camera id should not be in configurations of cameraprocessor since it is required to be specified inside environment
Otherwise it is possible to mistakenly start up camera processor without being guaranteed to have thought about the ID