### PR TITLE
FFT: Set prune to 24 hours from 1 week.

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -27,7 +27,7 @@ jobs:
         run: docker-compose down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Forwarder_Build.yml
+++ b/.github/workflows/Forwarder_Build.yml
@@ -28,5 +28,5 @@ jobs:
         run: docker-compose -f  VideoForwarder/compose/docker-compose_build_gpu.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Forwarder_Lint.yml
+++ b/.github/workflows/Forwarder_Lint.yml
@@ -31,5 +31,5 @@ jobs:
         run: docker-compose -f ./VideoForwarder/compose/docker-compose_lint.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Forwarder_Test_Unit.yml
+++ b/.github/workflows/Forwarder_Test_Unit.yml
@@ -34,5 +34,5 @@ jobs:
         run: docker-compose -f ./VideoForwarder/compose/docker-compose_test_unit.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Interface-Orchestrator.yml
+++ b/.github/workflows/Interface-Orchestrator.yml
@@ -35,5 +35,5 @@ jobs:
         run: docker-compose -f Interface/compose/docker-compose_test_integration.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Interface_Build.yml
+++ b/.github/workflows/Interface_Build.yml
@@ -23,5 +23,5 @@ jobs:
         run: docker-compose -f Interface/docker-compose.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Interface_Lint.yml
+++ b/.github/workflows/Interface_Lint.yml
@@ -23,5 +23,5 @@ jobs:
         run: docker-compose -f Interface/compose/docker-compose_lint.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Interface_Test_Unit.yml
+++ b/.github/workflows/Interface_Test_Unit.yml
@@ -34,5 +34,5 @@ jobs:
         run: docker-compose -f Interface/compose/docker-compose_test_unit.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Orchestrator_Build.yml
+++ b/.github/workflows/Orchestrator_Build.yml
@@ -23,5 +23,5 @@ jobs:
         run: docker-compose -f ./ProcessorOrchestrator/docker-compose.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Orchestrator_Lint.yml
+++ b/.github/workflows/Orchestrator_Lint.yml
@@ -31,5 +31,5 @@ jobs:
         run: docker-compose -f ./ProcessorOrchestrator/compose/docker-compose_lint.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Orchestrator_Test_Integration.yml
+++ b/.github/workflows/Orchestrator_Test_Integration.yml
@@ -47,5 +47,5 @@ jobs:
         run: docker-compose -f ./ProcessorOrchestrator/compose/docker-compose_test_integration.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Orchestrator_Test_Unit.yml
+++ b/.github/workflows/Orchestrator_Test_Unit.yml
@@ -46,5 +46,5 @@ jobs:
         run: docker-compose -f ./ProcessorOrchestrator/compose/docker-compose_test_unit.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Processor-Forwarder.yml
+++ b/.github/workflows/Processor-Forwarder.yml
@@ -31,7 +31,7 @@ jobs:
         run: docker-compose -f ./CameraProcessor/compose/docker-compose+forwarder.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}
       - name: Upload integration test report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Processor-Orchestrator.yml
+++ b/.github/workflows/Processor-Orchestrator.yml
@@ -31,7 +31,7 @@ jobs:
         run: docker-compose -f ./CameraProcessor/compose/docker-compose+orchestrator.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}
       - name: Upload integration test report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/Processor_Build.yml
+++ b/.github/workflows/Processor_Build.yml
@@ -23,5 +23,5 @@ jobs:
         run: docker-compose -f CameraProcessor/compose/docker-compose_test.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Processor_Lint.yml
+++ b/.github/workflows/Processor_Lint.yml
@@ -31,5 +31,5 @@ jobs:
         run: docker-compose -f ./CameraProcessor/compose/docker-compose_lint.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}

--- a/.github/workflows/Processor_Test_Unit.yml
+++ b/.github/workflows/Processor_Test_Unit.yml
@@ -32,7 +32,7 @@ jobs:
         run: docker-compose -f ./CameraProcessor/compose/docker-compose_test_unit.yml down --rmi all
         if: ${{ always() }}
       - name: Prune images
-        run: docker image prune --force --filter "until=168h"
+        run: docker image prune --force --filter "until=24h"
         if: ${{ always() }}
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Prunes Docker images after a single day instead of one week to save disk space on runners.